### PR TITLE
Add coordinate (de-)serialisation, including z

### DIFF
--- a/src/main/java/org/n52/jackson/datatype/jts/CoordinateDeserializer.java
+++ b/src/main/java/org/n52/jackson/datatype/jts/CoordinateDeserializer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.n52.jackson.datatype.jts;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.locationtech.jts.geom.Coordinate;
+
+import java.io.IOException;
+
+/**
+ * {@link JsonDeserializer} for {@link Coordinate}.
+ *
+ * @author João Rodrigues
+ */
+public class CoordinateDeserializer extends JsonDeserializer<Coordinate> {
+
+	/**
+     * Creates a new {@link CoordinateDeserializer}.
+     */
+
+    @Override
+    public Coordinate deserialize(JsonParser p, DeserializationContext context) throws IOException {
+        return deserializeCoordinate(p.readValueAs(JsonNode.class), context);
+    }
+
+    private Coordinate deserializeCoordinate(JsonNode node, DeserializationContext context)
+            throws JsonMappingException {
+        if (node.size() < 2) {
+            throw JsonMappingException.from(context, String.format("Invalid number of ordinates: %d", node.size()));
+        } else {
+            if (node.isArray()) {
+                double x = node.get(0).asDouble();
+                double y = node.get(1).asDouble();
+                if (node.size() < 3) {
+                    return new Coordinate(x, y);
+                } else {
+                    double z = node.get(2).asDouble();
+                    return new Coordinate(x, y, z);
+                }
+            } else if (node.isObject()) {
+                double x = node.get("x").asDouble();
+                double y = node.get("y").asDouble();
+                JsonNode z = node.get("z");
+                if (z == null) {
+                    return new Coordinate(x, y);
+                } else {
+                    return new Coordinate(x, y, z.asDouble());
+                }
+            } else {
+                 throw JsonMappingException.from(context, String.format("Unknown coordinates format: %s", node.toString()));
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/n52/jackson/datatype/jts/CoordinateSerializer.java
+++ b/src/main/java/org/n52/jackson/datatype/jts/CoordinateSerializer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.n52.jackson.datatype.jts;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.locationtech.jts.geom.Coordinate;
+
+import java.io.IOException;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/**
+ * {@link JsonSerializer} for {@link Coordinate}.
+ *
+ * @author João Rodrigues
+ */
+public class CoordinateSerializer extends JsonSerializer<Coordinate> {
+    static final int DEFAULT_DECIMAL_PLACES = 8;
+    private final NumberFormat decimalFormat;
+
+    /**
+     * Creates a new {@link CoordinateSerializer}.
+     */
+    public CoordinateSerializer() {
+        this(DEFAULT_DECIMAL_PLACES);
+    }
+
+    /**
+     * Creates a new {@link CoordinateSerializer}.
+     *
+     * @param decimalPlaces      The number of decimal places for encoded coordinates.
+     */
+    public CoordinateSerializer(int decimalPlaces) {
+        if (decimalPlaces < 0) {
+            throw new IllegalArgumentException("decimalPlaces < 0");
+        }
+        this.decimalFormat = createNumberFormat(decimalPlaces);
+    }
+
+    private NumberFormat createNumberFormat(int decimalPlaces) {
+        NumberFormat format = DecimalFormat.getInstance(Locale.ROOT);
+        format.setRoundingMode(RoundingMode.HALF_UP);
+        format.setMinimumFractionDigits(0);
+        format.setMaximumFractionDigits(decimalPlaces);
+        format.setGroupingUsed(false);
+        return format;
+    }
+
+    @Override
+    public Class<Coordinate> handledType() {
+        return Coordinate.class;
+    }
+
+    @Override
+    public void serialize(Coordinate value, JsonGenerator generator, SerializerProvider provider) throws IOException {
+        if (value == null) {
+            generator.writeNull();
+        } else {
+            serializeCoordinate(value, generator, provider);
+        }
+    }
+
+    private void serializeCoordinate(Coordinate value, JsonGenerator generator, SerializerProvider provider)
+            throws IOException {
+        generator.writeStartArray();
+        generator.writeNumber(decimalFormat.format(value.getX()));
+        generator.writeNumber(decimalFormat.format(value.getY()));
+        if (!Double.isNaN(value.getZ()) && Double.isFinite(value.getZ())) {
+            generator.writeNumber(decimalFormat.format(value.getZ()));
+        }
+        generator.writeEndArray();
+    }
+
+}

--- a/src/main/java/org/n52/jackson/datatype/jts/JtsModule.java
+++ b/src/main/java/org/n52/jackson/datatype/jts/JtsModule.java
@@ -19,6 +19,7 @@ package org.n52.jackson.datatype.jts;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -126,7 +127,8 @@ public class JtsModule extends SimpleModule {
     @Override
     public void setupModule(SetupContext context) {
         JsonDeserializer<Geometry> deserializer = getDeserializer();
-        addSerializer(Geometry.class, getSerializer());
+        addSerializer(Geometry.class, getGeometrySerializer());
+        addSerializer(Coordinate.class, getCoordinateSerializer());
         addDeserializer(Geometry.class, deserializer);
         addDeserializer(Point.class, new TypeSafeJsonDeserializer<>(Point.class, deserializer));
         addDeserializer(LineString.class, new TypeSafeJsonDeserializer<>(LineString.class, deserializer));
@@ -136,15 +138,20 @@ public class JtsModule extends SimpleModule {
         addDeserializer(MultiPolygon.class, new TypeSafeJsonDeserializer<>(MultiPolygon.class, deserializer));
         addDeserializer(GeometryCollection.class,
                         new TypeSafeJsonDeserializer<>(GeometryCollection.class, deserializer));
+        addDeserializer(Coordinate.class, new CoordinateDeserializer());
         super.setupModule(context);
     }
 
-    private JsonSerializer<Geometry> getSerializer() {
+    private JsonSerializer<Geometry> getGeometrySerializer() {
         return new GeometrySerializer(this.includeBoundingBox, this.decimalPlaces);
     }
 
     private JsonDeserializer<Geometry> getDeserializer() {
         return new GeometryDeserializer(geometryFactory);
+    }
+
+    private JsonSerializer<Coordinate> getCoordinateSerializer() {
+        return new CoordinateSerializer(this.decimalPlaces);
     }
 
 }


### PR DESCRIPTION
In addition to all the Geometry types (including point), in some cases the we are interested in (de-)serialising the coordinates themselves.
The deserialisation code aceppts both pairs/triples of coordinates, such as [X,Y, Z], as well as the format {'x': X, 'y': Y, 'z': Z}, where Z is, similarly to JTS, optional and signalled with a NaN. 